### PR TITLE
fix: Projectile movement

### DIFF
--- a/Source/MyProject/Actors/BaseClass/A_Collectable.cpp
+++ b/Source/MyProject/Actors/BaseClass/A_Collectable.cpp
@@ -43,7 +43,7 @@ AA_Collectable* FCollectableUtility::CloneChildActor
 		ESpawnActorCollisionHandlingMethod::AlwaysSpawn
 	);
 
-	for (UActorComponent* OriginalComponent : InObject->GetComponents())
+	for ( UActorComponent* OriginalComponent : InObject->GetComponents() )
 	{
 		// todo: use tag? (5.4 introduced)
 
@@ -57,7 +57,9 @@ AA_Collectable* FCollectableUtility::CloneChildActor
 			OriginalComponent->GetClass()
 		);
 
-		Destination->ReinitializeProperties(OriginalComponent);
+		Destination->ReinitializeProperties( OriginalComponent );
+		// Register the component for the any tick components.
+		Destination->RegisterComponent();
 	}
 
 	// fixme: inconsistent fetching (delegation);
@@ -66,6 +68,7 @@ AA_Collectable* FCollectableUtility::CloneChildActor
 	InDeferredFunction(ClonedObject);
 
 	UGameplayStatics::FinishSpawningActor(ClonedObject, InTransform);
+
 	return ClonedObject;
 }
 
@@ -156,7 +159,8 @@ void AA_Collectable::OnRep_Dummy(AA_Collectable* InPreviousDummy) const
 
 void AA_Collectable::OnRep_PhysicsInClient() const
 {
-	if ( CollisionComponent )
+	// Exclude the listen server case.
+	if ( GetNetMode() == NM_Client && CollisionComponent )
 	{
 		LOG_FUNC_PRINTF( LogCollectable , Log , "Applying physics flag %d and %s Client? : %d;" , bPhysicsInClient);
 		CollisionComponent->SetSimulatePhysics( bPhysicsInClient );
@@ -165,7 +169,8 @@ void AA_Collectable::OnRep_PhysicsInClient() const
 
 void AA_Collectable::OnRep_CollisionTypeInClient() const
 {
-	if ( CollisionComponent )
+	// Exclude the listen server case.
+	if ( GetNetMode() == NM_Client && CollisionComponent )
 	{
 		LOG_FUNC_PRINTF( LogCollectable , Log , "Applying the Collision type %s in client" , *EnumToString( CollisionTypeInClient.GetValue() ) );
 		CollisionComponent->SetCollisionEnabled( CollisionTypeInClient );

--- a/Source/MyProject/Actors/BaseClass/A_Weapon.cpp
+++ b/Source/MyProject/Actors/BaseClass/A_Weapon.cpp
@@ -14,7 +14,7 @@ AA_Weapon::AA_Weapon(const FObjectInitializer& ObjectInitializer) :
 	Super(ObjectInitializer.SetDefaultSubobjectClass<UC_WeaponAsset>(AssetComponentName))
 {
 	// Set this actor to call Tick() every frame.  You can turn this off to improve performance if you don't need it.
-	PrimaryActorTick.bCanEverTick = false;
+	PrimaryActorTick.bCanEverTick = true;
 
 	WeaponComponent = CreateDefaultSubobject<UC_Weapon>(WeaponComponentName);
 	WeaponComponent->SetNetAddressable();

--- a/Source/MyProject/Components/Weapon/C_ThrowWeapon.cpp
+++ b/Source/MyProject/Components/Weapon/C_ThrowWeapon.cpp
@@ -64,10 +64,15 @@ void UC_ThrowWeapon::SetUpSpawnedObject(AActor* InSpawnedActor)
 
 	if (AA_ThrowWeapon* ThrowWeapon = Cast<AA_ThrowWeapon>(InSpawnedActor))
 	{
+		ThrowWeapon->bAlwaysRelevant = true;
+		ThrowWeapon->GetCollisionComponent()->SetSimulatePhysics( false );
+		ThrowWeapon->GetCollisionComponent()->SetCollisionEnabled( ECollisionEnabled::QueryAndPhysics );
+
 		FRotator Rotator( 45.f , 0.f , 0.f );
-		ThrowWeapon->GetProjectileMovementComponent()->bSimulationEnabled = true;
+		ThrowWeapon->GetProjectileMovementComponent()->SetUpdatedComponent( ThrowWeapon->GetCollisionComponent() );
+		ThrowWeapon->GetProjectileMovementComponent()->SetActive( true );
 		ThrowWeapon->GetProjectileMovementComponent()->InitialSpeed = Force;
-		ThrowWeapon->GetProjectileMovementComponent()->Velocity = Rotator.RotateVector(ForwardVector * Force);
+		ThrowWeapon->GetProjectileMovementComponent()->Velocity = Rotator.RotateVector(ForwardVector).GetSafeNormal() * Force;
 	}
 
 	CookTimeCounter = 0.f;
@@ -94,5 +99,5 @@ void UC_ThrowWeapon::HandlePickUp( TScriptInterface<IPickingUp> InPickUpObject ,
 	AA_ThrowWeapon* ThrowWeapon = Cast<AA_ThrowWeapon>( GetOwner() );
 	check( ThrowWeapon );
 
-	ThrowWeapon->GetProjectileMovementComponent()->bSimulationEnabled = false;
+	ThrowWeapon->GetProjectileMovementComponent()->SetActive( false );
 }

--- a/Source/MyProject/Interfaces/AssetFetchable.cpp
+++ b/Source/MyProject/Interfaces/AssetFetchable.cpp
@@ -21,7 +21,10 @@ void IAssetFetchable::UpdateCollisionComponent(USceneComponent* RootComponent, U
 			);
 		}
 
-		RootComponent->AttachToComponent(NewComponent, FAttachmentTransformRules::SnapToTargetNotIncludingScale);
+		if (RootComponent) 
+		{
+			RootComponent->AttachToComponent(NewComponent, FAttachmentTransformRules::SnapToTargetNotIncludingScale);
+		}
 
 		// lazy initialization of collision component;
 		NewComponent->SetCollisionProfileName(CollisionProfileName);


### PR DESCRIPTION
Projectile movement component does not ticked because the cloned object does not register the component to the world.